### PR TITLE
fix(module): support Nuxt 4.2+ server handler registration

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -82,13 +82,21 @@ export default defineNuxtModule<ModuleOptions>({
       `
     }
 
+    const finalConfigOptions = Array.isArray(finalConfig.options)
+      ? finalConfig.options
+      : [finalConfig.options]
+
+    finalConfigOptions.forEach((_, index) => {
+      const handler = `${virtualModulePrefix}/${index}.mjs`
+
+      addServerHandler({
+        handler,
+        middleware: true,
+      })
+    })
+
     nuxt.hook('nitro:config', (nitroConfig) => {
       nitroConfig.virtual = nitroConfig.virtual || {}
-
-      // To array
-      const finalConfigOptions = Array.isArray(finalConfig.options)
-        ? finalConfig.options
-        : [finalConfig.options]
 
       finalConfigOptions.forEach((opts, index) => {
         const handler = `${virtualModulePrefix}/${index}.mjs`
@@ -97,11 +105,6 @@ export default defineNuxtModule<ModuleOptions>({
           opts,
           index,
         )
-
-        addServerHandler({
-          handler,
-          middleware: true,
-        })
       })
     })
   },


### PR DESCRIPTION
## Summary

  This fixes proxy middleware registration for Nuxt 4.2+.

  `nuxt-proxy-request` was calling `addServerHandler()` inside the `nitro:config` hook. In Nuxt 4.2, Nitro collects `nuxt.options.serverHandlers` before that hook runs, so  
  the proxy handler is no longer included in the final Nitro handlers list. As a result, proxied requests fall through to the app router and return 404.

  This change registers proxy handlers before `nitro:config`, and keeps the virtual module injection inside `nitro:config`.

  ## What changed

  - Move `addServerHandler()` out of the `nitro:config` hook
  - Keep virtual proxy module creation in `nitro:config`

  ## Why

  This preserves the existing behavior on older Nuxt versions and restores compatibility with Nuxt 4.2+.

  ## Testing

  I tested this change with:

  - `nuxt@4.0`
  - `nuxt@4.1`
  - `nuxt@4.2`
  - `nuxt@latest`

  The proxy works correctly across all of them.